### PR TITLE
Fix/camera

### DIFF
--- a/modules/x-engine-jsi-camera/iOS/Podfile
+++ b/modules/x-engine-jsi-camera/iOS/Podfile
@@ -11,10 +11,13 @@ def shared_pods
   pod 'x-engine-native-camera', :path =>X_ENGINE_MODULES+'/x-engine-native-camera'
   pod 'x-engine-native-direct_omp', :path =>X_ENGINE_MODULES+'/x-engine-native-direct_omp'
   pod 'x-engine-native-direct_microapp', :path =>X_ENGINE_MODULES+'/x-engine-native-direct_microapp'
+  pod 'x-engine-native-direct_microapp', :path =>X_ENGINE_MODULES+'/x-engine-native-direct_microapp'
+  
 
   pod 'x-engine-native-protocols', :path =>X_ENGINE_MODULES+'/x-engine-native-protocols'
-  pod 'x-engine-native-direct', :path =>X_ENGINE_MODULES+'/x-engine-native-direct'
-  pod 'x-engine-native-tabbar', :path =>X_ENGINE_MODULES+'/x-engine-native-tabbar'
+  pod 'x-engine-native-direct',    :path =>X_ENGINE_MODULES+'/x-engine-native-direct'
+  pod 'x-engine-native-tabbar',    :path =>X_ENGINE_MODULES+'/x-engine-native-tabbar'
+  pod 'x-engine-native-toast',     :path =>X_ENGINE_MODULES+'/x-engine-native-toast'
   pod 'JSONModel'
 end
 

--- a/modules/x-engine-jsi-camera/iOS/Podfile.lock
+++ b/modules/x-engine-jsi-camera/iOS/Podfile.lock
@@ -1,5 +1,6 @@
 PODS:
   - JSONModel (1.8.0)
+  - Toast (4.0.0)
   - x-engine-jsi-camera (2.8.1):
     - x-engine-native-core
     - x-engine-native-protocols
@@ -36,45 +37,54 @@ PODS:
   - x-engine-native-tabbar (1.0.0):
     - x-engine-native-core
     - x-engine-native-protocols
+  - x-engine-native-toast (1.0.0):
+    - Toast (~> 4.0.0)
+    - x-engine-native-core
+    - x-engine-native-protocols
 
 DEPENDENCIES:
   - JSONModel
   - x-engine-jsi-camera (from `../`)
-  - x-engine-native-camera (from `/Users/zk/git/company/working/x-engine/modules/x-engine-native-camera`)
-  - x-engine-native-core (from `/Users/zk/git/company/working/x-engine/modules/x-engine-native-core`)
-  - x-engine-native-direct (from `/Users/zk/git/company/working/x-engine/modules/x-engine-native-direct`)
-  - x-engine-native-direct_microapp (from `/Users/zk/git/company/working/x-engine/modules/x-engine-native-direct_microapp`)
-  - x-engine-native-direct_omp (from `/Users/zk/git/company/working/x-engine/modules/x-engine-native-direct_omp`)
-  - x-engine-native-jsi (from `/Users/zk/git/company/working/x-engine/modules/x-engine-native-jsi`)
-  - x-engine-native-protocols (from `/Users/zk/git/company/working/x-engine/modules/x-engine-native-protocols`)
-  - x-engine-native-tabbar (from `/Users/zk/git/company/working/x-engine/modules/x-engine-native-tabbar`)
+  - x-engine-native-camera (from `/Users/cwz/work/1-Zkty/x-engine/modules/x-engine-native-camera`)
+  - x-engine-native-core (from `/Users/cwz/work/1-Zkty/x-engine/modules/x-engine-native-core`)
+  - x-engine-native-direct (from `/Users/cwz/work/1-Zkty/x-engine/modules/x-engine-native-direct`)
+  - x-engine-native-direct_microapp (from `/Users/cwz/work/1-Zkty/x-engine/modules/x-engine-native-direct_microapp`)
+  - x-engine-native-direct_omp (from `/Users/cwz/work/1-Zkty/x-engine/modules/x-engine-native-direct_omp`)
+  - x-engine-native-jsi (from `/Users/cwz/work/1-Zkty/x-engine/modules/x-engine-native-jsi`)
+  - x-engine-native-protocols (from `/Users/cwz/work/1-Zkty/x-engine/modules/x-engine-native-protocols`)
+  - x-engine-native-tabbar (from `/Users/cwz/work/1-Zkty/x-engine/modules/x-engine-native-tabbar`)
+  - x-engine-native-toast (from `/Users/cwz/work/1-Zkty/x-engine/modules/x-engine-native-toast`)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - JSONModel
+    - Toast
 
 EXTERNAL SOURCES:
   x-engine-jsi-camera:
     :path: "../"
   x-engine-native-camera:
-    :path: "/Users/zk/git/company/working/x-engine/modules/x-engine-native-camera"
+    :path: "/Users/cwz/work/1-Zkty/x-engine/modules/x-engine-native-camera"
   x-engine-native-core:
-    :path: "/Users/zk/git/company/working/x-engine/modules/x-engine-native-core"
+    :path: "/Users/cwz/work/1-Zkty/x-engine/modules/x-engine-native-core"
   x-engine-native-direct:
-    :path: "/Users/zk/git/company/working/x-engine/modules/x-engine-native-direct"
+    :path: "/Users/cwz/work/1-Zkty/x-engine/modules/x-engine-native-direct"
   x-engine-native-direct_microapp:
-    :path: "/Users/zk/git/company/working/x-engine/modules/x-engine-native-direct_microapp"
+    :path: "/Users/cwz/work/1-Zkty/x-engine/modules/x-engine-native-direct_microapp"
   x-engine-native-direct_omp:
-    :path: "/Users/zk/git/company/working/x-engine/modules/x-engine-native-direct_omp"
+    :path: "/Users/cwz/work/1-Zkty/x-engine/modules/x-engine-native-direct_omp"
   x-engine-native-jsi:
-    :path: "/Users/zk/git/company/working/x-engine/modules/x-engine-native-jsi"
+    :path: "/Users/cwz/work/1-Zkty/x-engine/modules/x-engine-native-jsi"
   x-engine-native-protocols:
-    :path: "/Users/zk/git/company/working/x-engine/modules/x-engine-native-protocols"
+    :path: "/Users/cwz/work/1-Zkty/x-engine/modules/x-engine-native-protocols"
   x-engine-native-tabbar:
-    :path: "/Users/zk/git/company/working/x-engine/modules/x-engine-native-tabbar"
+    :path: "/Users/cwz/work/1-Zkty/x-engine/modules/x-engine-native-tabbar"
+  x-engine-native-toast:
+    :path: "/Users/cwz/work/1-Zkty/x-engine/modules/x-engine-native-toast"
 
 SPEC CHECKSUMS:
   JSONModel: 02ab723958366a3fd27da57ea2af2113658762e9
+  Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
   x-engine-jsi-camera: 4f0e5cab50ec441c897161329c39e23f368a6a79
   x-engine-native-camera: f81c179d6c8995491cf118b26a69a3e7f03cec79
   x-engine-native-core: 7fa925c39f2e8664dabf44a0aba8b2f5552dc4ed
@@ -84,7 +94,8 @@ SPEC CHECKSUMS:
   x-engine-native-jsi: de8ec07ba9253330b7ca0c1e3abfeb775b7f6eae
   x-engine-native-protocols: 3fce367890ca46435a6c64b0bcd7d03a427ab27b
   x-engine-native-tabbar: 7b4b3e9a3c218dfd5bc7516032fc994dc0e1d15d
+  x-engine-native-toast: 3c8b247661a414c40e0c25235fd45ad6d850af36
 
-PODFILE CHECKSUM: 17d4b8da3d762421bdd17f86e0ab646750ccc481
+PODFILE CHECKSUM: 85e906ab1323bce274f8a6a20090d57eb9a8ee6c
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.10.1

--- a/modules/x-engine-jsi-camera/iOS/camera.xcodeproj/project.pbxproj
+++ b/modules/x-engine-jsi-camera/iOS/camera.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		58D209A0261346360082ADC3 /* xengine_jsi_camera.m in Sources */ = {isa = PBXBuildFile; fileRef = 58D2099F261346360082ADC3 /* xengine_jsi_camera.m */; };
 		64354DB0471E360AC7A3B8A8 /* libPods-camera.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E8CA3713E96420DF83249E1 /* libPods-camera.a */; };
 		6A6EA1E26D7AD8995610C648 /* libPods-cameraUITests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 42511EECCA68257EBB3854A8 /* libPods-cameraUITests.a */; };
+		A4B08B6426CA4CCA00383541 /* AssetsLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4B08B6326CA4CCA00383541 /* AssetsLibrary.framework */; };
 		E6482C9CFE9A42FEC2328834 /* libPods-cameraTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D15B7D44DF761F640EDBA44 /* libPods-cameraTests.a */; };
 /* End PBXBuildFile section */
 
@@ -80,6 +81,7 @@
 		8A4FCA27E7FE59204E44E83A /* Pods-abstract-cameraTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-abstract-cameraTests.debug.xcconfig"; path = "Target Support Files/Pods-abstract-cameraTests/Pods-abstract-cameraTests.debug.xcconfig"; sourceTree = "<group>"; };
 		9272408DD3356C0889C56BE8 /* Pods-camera.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-camera.release.xcconfig"; path = "Target Support Files/Pods-camera/Pods-camera.release.xcconfig"; sourceTree = "<group>"; };
 		9E8CA3713E96420DF83249E1 /* libPods-camera.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-camera.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A4B08B6326CA4CCA00383541 /* AssetsLibrary.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AssetsLibrary.framework; path = System/Library/Frameworks/AssetsLibrary.framework; sourceTree = SDKROOT; };
 		AA61277E946A43DAD1657AED /* Pods-abstract-cameraUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-abstract-cameraUITests.debug.xcconfig"; path = "Target Support Files/Pods-abstract-cameraUITests/Pods-abstract-cameraUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		C41BD34806B6619ACBB99D5D /* Pods-ModuleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ModuleApp.debug.xcconfig"; path = "Target Support Files/Pods-ModuleApp/Pods-ModuleApp.debug.xcconfig"; sourceTree = "<group>"; };
 		DC24F7764E32FC4DBD8E03D7 /* Pods-camera.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-camera.debug.xcconfig"; path = "Target Support Files/Pods-camera/Pods-camera.debug.xcconfig"; sourceTree = "<group>"; };
@@ -92,6 +94,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A4B08B6426CA4CCA00383541 /* AssetsLibrary.framework in Frameworks */,
 				003F95DA24DA4A6100633E1F /* libc++.tbd in Frameworks */,
 				64354DB0471E360AC7A3B8A8 /* libPods-camera.a in Frameworks */,
 			);
@@ -221,6 +224,7 @@
 		B1C6B1D81743291D8E148429 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				A4B08B6326CA4CCA00383541 /* AssetsLibrary.framework */,
 				003F95D924DA4A6100633E1F /* libc++.tbd */,
 				9E8CA3713E96420DF83249E1 /* libPods-camera.a */,
 				6D15B7D44DF761F640EDBA44 /* libPods-cameraTests.a */,
@@ -680,7 +684,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 2GBSCJ7C97;
+				DEVELOPMENT_TEAM = 2ZE56AMZE7;
 				INFOPLIST_FILE = "$(SRCROOT)/camera/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -702,7 +706,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 2GBSCJ7C97;
+				DEVELOPMENT_TEAM = 2ZE56AMZE7;
 				INFOPLIST_FILE = "$(SRCROOT)/camera/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/modules/x-engine-jsi-camera/iOS/camera/EntryViewController.m
+++ b/modules/x-engine-jsi-camera/iOS/camera/EntryViewController.m
@@ -19,7 +19,7 @@
 -(void) pushTestModule{
     id<iDirectManager> director = [[XENativeContext sharedInstance] getModuleByProtocol:@protocol(iDirectManager)];
 
-    [director push:@"omp" host:@"192.168.1.15:9111" pathname:@"" fragment:@"/" query:nil params:@{@"hideNavbar":@YES}];
+    [director push:@"omp" host:@"10.2.128.61:9111" pathname:@"" fragment:@"/" query:nil params:@{@"hideNavbar":@YES}];
 }
 
 - (void)viewDidLoad {

--- a/modules/x-engine-native-camera/iOS/Class/Native_camera.m
+++ b/modules/x-engine-native-camera/iOS/Class/Native_camera.m
@@ -106,80 +106,76 @@ NATIVE_MODULE(Native_camera)
     }
 }
 
-- (void)choosePhotos:(CameraParamsDTO*)dto {
-    PHFetchOptions *options = [PHFetchOptions new];
-    PHFetchResult *topLevelUserCollections = [PHAssetCollection fetchTopLevelUserCollectionsWithOptions:options];
-    PHAssetCollectionSubtype subType = PHAssetCollectionSubtypeAlbumRegular;
-    PHFetchResult *smartAlbumsResult = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:subType options:options];
-    
-    NSMutableArray *photoGroups = [NSMutableArray array];
-    [topLevelUserCollections enumerateObjectsUsingBlock:^(id _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-        if ([obj isKindOfClass:[PHAssetCollection class]]) {
-             PHAssetCollection *asset = (PHAssetCollection *)obj;
-             PHFetchResult *result = [PHAsset fetchAssetsInAssetCollection:asset options:[PHFetchOptions new]];
-             if (result.count > 0) {
-                 NSLog(@"%@", asset);
-                 NSLog(@"%@", asset.localizedTitle);
-             }
-         }
-    }];
-
-    [smartAlbumsResult enumerateObjectsWithOptions:NSEnumerationReverse usingBlock:^(id _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-        if ([obj isKindOfClass:[PHAssetCollection class]]) {
-           PHAssetCollection *asset = (PHAssetCollection *)obj;
-           PHFetchOptions *options = [[PHFetchOptions alloc] init];
-           options.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:NO]];
-                
-           PHFetchResult *result = [PHAsset fetchAssetsInAssetCollection:asset options:options];
-           if(result.count > 0 && asset.assetCollectionSubtype != PHAssetCollectionSubtypeSmartAlbumVideos) {
-               NSLog(@"%@", asset);
-               NSLog(@"%@", asset.localizedTitle);
-            }
-         }
-    }];
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-}
+//- (void)choosePhotos:(CameraParamsDTO*)dto {
+//    PHFetchOptions *options = [PHFetchOptions new];
+//    PHFetchResult *topLevelUserCollections = [PHAssetCollection fetchTopLevelUserCollectionsWithOptions:options];
+//    PHAssetCollectionSubtype subType = PHAssetCollectionSubtypeAlbumRegular;
+//    PHFetchResult *smartAlbumsResult = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:subType options:options];
+//
+//    NSMutableArray *photoGroups = [NSMutableArray array];
+//    [topLevelUserCollections enumerateObjectsUsingBlock:^(id _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+//        if ([obj isKindOfClass:[PHAssetCollection class]]) {
+//             PHAssetCollection *asset = (PHAssetCollection *)obj;
+//             PHFetchResult *result = [PHAsset fetchAssetsInAssetCollection:asset options:[PHFetchOptions new]];
+//             if (result.count > 0) {
+//                 NSLog(@"%@", asset);
+//                 NSLog(@"%@", asset.localizedTitle);
+//             }
+//         }
+//    }];
+//
+//    [smartAlbumsResult enumerateObjectsWithOptions:NSEnumerationReverse usingBlock:^(id _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+//        if ([obj isKindOfClass:[PHAssetCollection class]]) {
+//           PHAssetCollection *asset = (PHAssetCollection *)obj;
+//           PHFetchOptions *options = [[PHFetchOptions alloc] init];
+//           options.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:NO]];
+//
+//           PHFetchResult *result = [PHAsset fetchAssetsInAssetCollection:asset options:options];
+//           if(result.count > 0 && asset.assetCollectionSubtype != PHAssetCollectionSubtypeSmartAlbumVideos) {
+//               NSLog(@"%@", asset);
+//               NSLog(@"%@", asset.localizedTitle);
+//            }
+//         }
+//    }];
+//}
 
 #pragma 调起相册
-//- (void)choosePhotos:(CameraParamsDTO*)dto {
-//    __weak typeof(self) weakself = self;
-//    ZKTY_TZImagePickerController *imagePickerVc = [[ZKTY_TZImagePickerController alloc] initWithMaxImagesCount:dto.photoCount delegate:self];
-//    imagePickerVc.allowTakeVideo = NO;
-//    imagePickerVc.allowPickingVideo = NO;
-//    [imagePickerVc setDidFinishPickingPhotosHandle:^(NSArray<UIImage *> *photos, NSArray *assets, BOOL isSelectOriginalPhoto) {
-//        NSMutableDictionary * ret = [NSMutableDictionary new];
-//        NSMutableArray * photoarrays=  [NSMutableArray new];
-//        NSDictionary* argsDic = dto.args;
-//        float maxBytes = argsDic[@"bytes"]?[argsDic[@"bytes"] floatValue]:4000.0f;
-//        float q = argsDic[@"quality"]?[argsDic[@"quality"] floatValue]:1.0f;
-//
-//        for(int i = 0; i< photos.count; i++){
-////            UIImage* image=  [self parseImage: Width:argsDic[@"width"] height:argsDic[@"height"] quality:argsDic[@"quality"] bytes:argsDic[@"bytes"]];
-//
-//            NSData* imageData= [XToolImage compressImage:photos[i] toMaxDataSizeKBytes:maxBytes miniQuality:q];
-//            UIImage* image = [UIImage imageWithData:imageData];
-//            [photoarrays addObject: @{
-//                @"retImage":[weakself UIImageToBase64Str:image],
-//                @"contentType":@"image/png",
-//                @"width": [NSNumber numberWithDouble:image.size.width],
-//                @"height":[NSNumber numberWithDouble:image.size.height],
-//                @"fileName":[NSString stringWithFormat:@"pic_%@.png",[weakself getDateFormatterString]]
-//            }];
+- (void)choosePhotos:(CameraParamsDTO*)dto {
+    __weak typeof(self) weakself = self;
+    ZKTY_TZImagePickerController *imagePickerVc = [[ZKTY_TZImagePickerController alloc] initWithMaxImagesCount:dto.photoCount delegate:self];
+    imagePickerVc.allowTakeVideo = NO;
+    imagePickerVc.allowPickingVideo = NO;
+    [imagePickerVc setDidFinishPickingPhotosHandle:^(NSArray<UIImage *> *photos, NSArray *assets, BOOL isSelectOriginalPhoto) {
+        
+//        NSLog(@"%@", photos);
+//        NSLog(@"%@", assets);
+        
+//        for (PHAsset *asset in assets) {
+////            PHFetchOptions *options = [PHFetchOptions ]
+//            [PHAsset fetchAssetsInAssetCollection:asset options:includeAllBurstAssets];
 //        }
-//        ret[@"data"] = photoarrays;
-//        [weakself sendParamtoWeb:ret];
-//    }];
-//    [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:imagePickerVc animated:YES completion:nil];
-//}
+        NSMutableDictionary * ret = [NSMutableDictionary new];
+        NSMutableArray * photoarrays=  [NSMutableArray new];
+        NSDictionary* argsDic = dto.args;
+        float maxBytes = argsDic[@"bytes"]?[argsDic[@"bytes"] floatValue]:4000.0f;
+        float q = argsDic[@"quality"]?[argsDic[@"quality"] floatValue]:1.0f;
+
+        for(int i = 0; i< photos.count; i++){
+            NSData* imageData= [XToolImage compressImage:photos[i] toMaxDataSizeKBytes:maxBytes miniQuality:q];
+            UIImage* image = [UIImage imageWithData:imageData];
+            [photoarrays addObject: @{
+                @"retImage":[weakself UIImageToBase64Str:image],
+                @"contentType":@"image/png",
+                @"width": [NSNumber numberWithDouble:image.size.width],
+                @"height":[NSNumber numberWithDouble:image.size.height],
+                @"fileName":[NSString stringWithFormat:@"pic_%@.png",[weakself getDateFormatterString]]
+            }];
+        }
+        ret[@"data"] = photoarrays;
+        [weakself sendParamtoWeb:ret];
+    }];
+    [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:imagePickerVc animated:YES completion:nil];
+}
 
 #pragma UIImagePickerControllerDelegate
 - (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary *)info {
@@ -308,7 +304,7 @@ NATIVE_MODULE(Native_camera)
     }
     return dic;
 }
-//
+
 //- (UIImage*)parseImage:(UIImage *)image Width:(NSString *)imageWidth height:(NSString *)imageHeight quality:(NSString *)imageQuality bytes:(NSString *)imageBytes{
 //    NSData *imageData;
 //    CGFloat width_height_per = image.size.width/image.size.height;


### PR DESCRIPTION
- 没有对相册进行授权时, 点保存图片会崩溃
  - 原因:ios11开始，判断权限的方式必须是异步的,如果同步调用会崩溃
  - 已解决

- 保存图片提示成功, 但实际相册中并没有 要保存的图片
    - 原因: 异步开启下载图片 忘记把dto传给调用的方法
    - 已解决